### PR TITLE
Fix missing security attribute on external links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,10 +9,10 @@ function App() {
   return (
     <>
       <div>
-        <a href="https://vite.dev" target="_blank">
+        <a href="https://vite.dev" target="_blank" rel="noopener noreferrer">
           <img src={viteLogo} className="logo" alt="Vite logo" />
         </a>
-        <a href="https://react.dev" target="_blank">
+        <a href="https://react.dev" target="_blank" rel="noopener noreferrer">
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
       </div>


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` on external links in `App.jsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_68505114ecbc8332b8b615d439b788cd