### PR TITLE
Fix README bullet layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This template provides a minimal setup to get React working in Vite with HMR and
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc)
+   uses [SWC](https://swc.rs/) for Fast Refresh
 
 ## Expanding the ESLint configuration
 


### PR DESCRIPTION
## Summary
- tweak plugin-react-swc bullet so `Fast Refresh` remains together

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6850522982608332b3b2994eef7d194c