### PR TITLE
Fix Lookify title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# React + Vite
+# Lookify
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Lookify</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- rename the default HTML title to "Lookify"
- update README heading to match

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6850533e06a883329cb251de15d1f921