### PR TITLE
Add Vitest test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Running Tests
+
+This project uses [Vitest](https://vitest.dev/) and React Testing Library for unit tests.
+
+```bash
+npm test
+```
+
+The command runs Vitest in watch mode. Press `q` to quit.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -22,6 +23,9 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.4.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.4.3"
   }
 }

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import App from './App'
+
+describe('App', () => {
+  it('increments count on click', async () => {
+    render(<App />)
+    const button = screen.getByRole('button', { name: /count is/i })
+    await userEvent.click(button)
+    expect(button).toHaveTextContent('count is 1')
+  })
+})

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.js',
+  },
 })


### PR DESCRIPTION
## Summary
- add Vitest and React Testing Library config
- configure Vite to run tests
- create simple counter test
- document test command in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68505342e7048332b1885038250c669f