### PR TITLE
Add Lookify planning docs and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,39 @@
-# Lookify
+# Lookify – Tu estilista social con IA
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Lookify es una aplicación web que combina inteligencia artificial, moda real y el poder de la comunidad para ayudarte a decidir qué ponerte y descubrir nuevas prendas.
 
-Currently, two official plugins are available:
+## Características principales
+- **Mi Armario digital**: organiza tus prendas por categorías y genera looks solo con lo que ya tienes.
+- **Sugerencias automáticas de outfits**: la IA mezcla tus prendas con recomendaciones de tiendas online y proporciona enlaces directos de compra.
+- **Funciones sociales**: comparte tus looks, recibe opiniones con encuestas y participa en desafíos semanales de estilo.
+- **Filtros inteligentes**: personaliza los resultados por estilo, clima, ocasión o colores favoritos.
+- **Modelo de monetización**: enlaces afiliados, publicidad integrada y plan premium con extras exclusivos.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Plan de componentes y rutas
+- `/` – feed principal con los looks recomendados y publicaciones de la comunidad.
+- `/armario` – componente **Closet** para gestionar las prendas guardadas y subir nuevas fotos.
+- `/crear-look` – componente **OutfitGenerator** para solicitar sugerencias de la IA.
+- `/perfil/:usuario` – componente **Profile** con publicaciones, seguidores y armario público.
+- Otros componentes: **LookCard**, **Survey**, **ShoppingLink**, entre otros.
 
-## Expanding the ESLint configuration
+## Integración con APIs y servicios de IA
+- Conexión a catálogos de marcas mediante APIs REST o feeds de productos para obtener imágenes, nombres y precios.
+- Comunicación con servicios de IA (ChatGPT o Jules.ai) a través de un backend que reciba las prendas del usuario y devuelva las combinaciones sugeridas.
+- El front-end consume estas sugerencias desde endpoints propios (`/api/outfits`, `/api/items`) y muestra las prendas con enlaces directos de compra.
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
-
-## Running Tests
-
-This project uses [Vitest](https://vitest.dev/) and React Testing Library for unit tests.
+## Desarrollo
+Este proyecto usa [Vite](https://vitejs.dev/) y [React](https://react.dev). Para ejecutar el entorno de desarrollo:
 
 ```bash
 npm install
+npm run dev
 ```
+
+Para ejecutar los tests unitarios:
 
 ```bash
 npm test
 ```
-
-The command runs Vitest in watch mode. Press `q` to quit.
 
 ## License
 

--- a/docs/PLANNING.md
+++ b/docs/PLANNING.md
@@ -1,0 +1,30 @@
+# Plan de Componentes, Rutas y APIs
+
+Este documento resume la estructura inicial de la aplicación y las integraciones externas previstas.
+
+## Componentes principales
+- **AppLayout**: contenedor general con cabecera y navegación.
+- **Feed**: muestra el flujo de publicaciones y looks recomendados.
+- **Closet**: gestión del armario personal del usuario.
+- **OutfitGenerator**: formulario para solicitar combinaciones a la IA.
+- **Profile**: página de perfil de cada usuario.
+- **LookCard**: tarjeta reutilizable para cada outfit o prenda.
+- **Survey**: módulo para votaciones rápidas tipo "¿Cuál me pongo?".
+- **ShoppingLink**: enlace de compra con imagen, precio y marca.
+
+## Rutas de React
+- `/` – `Feed`
+- `/armario` – `Closet`
+- `/crear-look` – `OutfitGenerator`
+- `/perfil/:usuario` – `Profile`
+- `/look/:id` – detalle de un look concreto
+
+## Integración con APIs externas
+1. **Catálogos de productos**: se consultarán mediante APIs REST de las marcas o mediante un feed de productos (CSV/JSON). Estas solicitudes se realizarán desde un backend que almacenará los resultados y filtrará por categoría o disponibilidad.
+2. **Servicios de IA (ChatGPT/Jules.ai)**:
+   - El front-end enviará las prendas seleccionadas y preferencias del usuario a un endpoint backend `/api/generate-look`.
+   - El backend llamará a la IA con las imágenes, texto descriptivo o IDs de prendas para obtener la propuesta de outfit.
+   - La respuesta incluirá combinaciones y enlaces sugeridos para que el front-end los muestre.
+3. **Usuarios y autenticación**: se utilizará un servicio de autenticación (por ejemplo, Firebase Auth) para manejar inicios de sesión y perfiles.
+
+Este plan sirve como punto de partida y podrá evolucionar a medida que se implementen nuevas funcionalidades.


### PR DESCRIPTION
## Summary
- add detailed app overview to README
- outline component and route plan in docs

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ff2382348332a0491fae6547fd1d